### PR TITLE
Initial creation of PostgreSQL stats backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ To use this backend you must do the following:
     pguser: "user",
     pgpass: undefined,
     pgdb: "postgres",
+    pgport: 5432,
+    pginit: true,
     port: 8125,
     backends: [ "/path/to/statsdPostgresBackend" ]
 }
@@ -20,9 +22,5 @@ To use this backend you must do the following:
 4. ?????
 5. Profit!
 
-### Caveats
-There are a couple of caveats with this module at the moment.
-
-1. The database user needs to be able to create tables and functions as this is how it is currently initialized. Ideally the initialization script can be run separately to avoid giving the database user such permissions but at the moment it'll try running it anyway on start-up.
-
-2. At the moment this **only stores counts**! There are a lot of considerations when storing statsd data that simply haven't been factored into this backend yet.
+### PostgreSQL Initialization
+If the ```pginit``` configuration value is set then it will attempt to initialize PostgreSQL. If the user does not have access to create tables and functions then you must run it separately and set ```pginit``` to false.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# A statsd PostgreSQL Backend
+This backend supports storing statsd data into PostgreSQL.
+
+## Usage
+To use this backend you must do the following:
+
+1. Run ```npm install``` in the directory in which you cloned this repo into
+2. Update your statsd configuration to add the following properties:
+```javascript
+{
+    pghost: "localhost",
+    pguser: "user",
+    pgpass: undefined,
+    pgdb: "postgres",
+    port: 8125,
+    backends: [ "/path/to/statsdPostgresBackend" ]
+}
+```
+3. After ensuring PostgreSQL is running, start-up statsd
+4. ?????
+5. Profit!
+
+### Caveats
+There are a couple of caveats with this module at the moment.
+
+1. The database user needs to be able to create tables and functions as this is how it is currently initialized. Ideally the initialization script can be run separately to avoid giving the database user such permissions but at the moment it'll try running it anyway on start-up.
+
+2. At the moment this **only stores counts**! There are a lot of considerations when storing statsd data that simply haven't been factored into this backend yet.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "bakula-statsd",
+  "name": "statsd-postgresql-backend",
   "version": "1.0.0",
-  "description": "A docker container and postgres backend for statsd to be used with bakula",
+  "description": "A docker container and postgres backend for statsd.",
   "main": "statsdPostgresBackend.js",
-  "license": "ISC",
   "dependencies": {
     "pg": "4.4.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bakula-statsd",
+  "version": "1.0.0",
+  "description": "A docker container and postgres backend for statsd to be used with bakula",
+  "main": "statsdPostgresBackend.js",
+  "license": "ISC",
+  "dependencies": {
+    "pg": "4.4.3"
+  }
+}

--- a/psql/init.sql
+++ b/psql/init.sql
@@ -1,6 +1,3 @@
-/* Drops the tables if they exist */
-DROP TABLE IF EXISTS stats CASCADE;
-
 /*
     Create a table to hold all bakula stats
 

--- a/psql/init.sql
+++ b/psql/init.sql
@@ -1,0 +1,137 @@
+/* Drops the tables if they exist */
+DROP TABLE IF EXISTS stats CASCADE;
+
+/*
+    Create a table to hold all bakula stats
+
+    This table is going to be written to with high frequency but since it needs
+    to provide stats in real time we have to both write and read with high frequency.
+    Therefore there is a single index in this first version to accommodate write
+    moreso than read. This will probably be revisited later (possibly to remove
+    the existing index or to make more indexes marked as CONCURRENT)
+*/
+CREATE TABLE IF NOT EXISTS stats (
+    collected TIMESTAMP NOT NULL UNIQUE DEFAULT CURRENT_TIMESTAMP,
+    metric TEXT NOT NULL,
+    type TEXT NOT NULL,
+    value TEXT NOT NULL
+);
+
+/* Create add_stat function that takes the timestamp plus the stats */
+DROP FUNCTION IF EXISTS add_stat(TIMESTAMP, TEXT, TEXT, TEXT);
+CREATE FUNCTION add_stat (
+    collected TIMESTAMP,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) RETURNS void AS $$
+BEGIN
+    INSERT INTO stats (collected, metric, type, value) VALUES (collected, metric, type, value);
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create another add_stat function that uses the default timestamp and takes the stats */
+DROP FUNCTION IF EXISTS add_stat(TEXT, TEXT, TEXT);
+CREATE FUNCTION add_stat (
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) RETURNS void AS $$
+BEGIN
+    INSERT INTO stats (metric, type, value) VALUES (metric, type, value);
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create get_stat function that returns everything because no one was specific */
+DROP FUNCTION IF EXISTS get_stat();
+CREATE FUNCTION get_stat ()
+RETURNS TABLE(
+    collected TIMESTAMP,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+        SELECT stats.collected,
+            stats.metric,
+            stats.type,
+            stats.value
+        FROM stats;
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create get_stat function limits what's returned to a start and ending timestamp */
+DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP);
+CREATE FUNCTION get_stat (
+    start_time TIMESTAMP,
+    end_time TIMESTAMP
+)
+RETURNS TABLE(
+    collected TIMESTAMP,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+        SELECT stats.collected,
+            stats.metric,
+            stats.type,
+            stats.value
+        FROM stats
+        WHERE stats.collected BETWEEN start_time AND end_time;
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create get_stat function limits what's returned to a start, ending timestamp and metric name */
+DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP, TEXT);
+CREATE FUNCTION get_stat (
+    start_time TIMESTAMP,
+    end_time TIMESTAMP,
+    matric TEXT
+)
+RETURNS TABLE(
+    collected TIMESTAMP,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+        SELECT stats.collected,
+            stats.metric,
+            stats.type,
+            stats.value
+        FROM stats
+        WHERE stats.collected BETWEEN start_time AND end_time
+            AND stats.metric = metric;
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create get_stat function limits what's returned to a start, ending timestamp, metric name and type */
+DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP, TEXT, TEXT);
+CREATE FUNCTION get_stat (
+    start_time TIMESTAMP,
+    end_time TIMESTAMP,
+    matric TEXT,
+    metric_type TEXT
+)
+RETURNS TABLE(
+    collected TIMESTAMP,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+        SELECT stats.collected,
+            stats.metric,
+            stats.type,
+            stats.value
+        FROM stats
+        WHERE stats.collected BETWEEN start_time AND end_time
+            AND stats.metric = metric
+            AND stats.type = metric_type;
+END;
+$$ LANGUAGE plpgsql;

--- a/psql/init.sql
+++ b/psql/init.sql
@@ -3,47 +3,56 @@
 
     This table is going to be written to with high frequency but since it needs
     to provide stats in real time we have to both write and read with high frequency.
-    Therefore there is a single index in this first version to accommodate write
-    moreso than read. This will probably be revisited later (possibly to remove
-    the existing index or to make more indexes marked as CONCURRENT)
+    Therefore we are only indexing collected so further queries minimize their table
+    scans to a specific timeframe (all get calls request a start and end time). This
+    may need to be revised later on.
 */
 CREATE TABLE IF NOT EXISTS stats (
-    collected TIMESTAMP NOT NULL UNIQUE DEFAULT CURRENT_TIMESTAMP,
+    collected TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    topic TEXT NULL,
+    category TEXT NULL,
+    subcategory TEXT NULL,
     metric TEXT NOT NULL,
     type TEXT NOT NULL,
-    value TEXT NOT NULL
+    value TEXT NOT NULL,
+    CONSTRAINT stats_pk PRIMARY KEY (collected, metric, type)
 );
 
-/* Create add_stat function that takes the timestamp plus the stats */
-DROP FUNCTION IF EXISTS add_stat(TIMESTAMP, TEXT, TEXT, TEXT);
+/* Create a add_stat overload */
+DROP FUNCTION IF EXISTS add_stat(TIMESTAMP, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT);
 CREATE FUNCTION add_stat (
-    collected TIMESTAMP,
-    metric TEXT,
-    type TEXT,
-    value TEXT
+    vcollected TIMESTAMP,
+    vtopic TEXT,
+    vcategory TEXT,
+    vsubcategory TEXT,
+    vmetric TEXT,
+    vtype TEXT,
+    vvalue TEXT
 ) RETURNS void AS $$
 BEGIN
-    INSERT INTO stats (collected, metric, type, value) VALUES (collected, metric, type, value);
+    INSERT INTO stats (collected, topic, category, subcategory, metric, type, value)
+    SELECT vcollected, vtopic, vcategory, vsubcategory, vmetric, vtype, vvalue
+    WHERE NOT EXISTS (SELECT 1
+        FROM stats
+        WHERE stats.collected = vcollected
+        AND stats.topic = vtopic
+        AND stats.category = vcategory
+        AND stats.subcategory = vsubcategory
+        AND stats.metric = vmetric
+        AND stats.type = vtype
+        AND stats.value = vvalue
+    );
 END;
 $$ LANGUAGE plpgsql;
 
-/* Create another add_stat function that uses the default timestamp and takes the stats */
-DROP FUNCTION IF EXISTS add_stat(TEXT, TEXT, TEXT);
-CREATE FUNCTION add_stat (
-    metric TEXT,
-    type TEXT,
-    value TEXT
-) RETURNS void AS $$
-BEGIN
-    INSERT INTO stats (metric, type, value) VALUES (metric, type, value);
-END;
-$$ LANGUAGE plpgsql;
-
-/* Create get_stat function that returns everything because no one was specific */
+/* Create a get_stat overload */
 DROP FUNCTION IF EXISTS get_stat();
 CREATE FUNCTION get_stat ()
 RETURNS TABLE(
     collected TIMESTAMP,
+    topic TEXT,
+    category TEXT,
+    subcategory TEXT,
     metric TEXT,
     type TEXT,
     value TEXT
@@ -51,6 +60,9 @@ RETURNS TABLE(
 BEGIN
     RETURN QUERY
         SELECT stats.collected,
+            stats.topic,
+            stats.category,
+            stats.subcategory,
             stats.metric,
             stats.type,
             stats.value
@@ -58,7 +70,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-/* Create get_stat function limits what's returned to a start and ending timestamp */
+/* Create a get_stat overload */
 DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP);
 CREATE FUNCTION get_stat (
     start_time TIMESTAMP,
@@ -66,6 +78,9 @@ CREATE FUNCTION get_stat (
 )
 RETURNS TABLE(
     collected TIMESTAMP,
+    topic TEXT,
+    category TEXT,
+    subcategory TEXT,
     metric TEXT,
     type TEXT,
     value TEXT
@@ -73,6 +88,9 @@ RETURNS TABLE(
 BEGIN
     RETURN QUERY
         SELECT stats.collected,
+            stats.topic,
+            stats.category,
+            stats.subcategory,
             stats.metric,
             stats.type,
             stats.value
@@ -81,15 +99,18 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-/* Create get_stat function limits what's returned to a start, ending timestamp and metric name */
+/* Create a get_stat overload */
 DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP, TEXT);
 CREATE FUNCTION get_stat (
     start_time TIMESTAMP,
     end_time TIMESTAMP,
-    matric TEXT
+    vmatric TEXT
 )
 RETURNS TABLE(
     collected TIMESTAMP,
+    topic TEXT,
+    category TEXT,
+    subcategory TEXT,
     metric TEXT,
     type TEXT,
     value TEXT
@@ -97,25 +118,31 @@ RETURNS TABLE(
 BEGIN
     RETURN QUERY
         SELECT stats.collected,
+            stats.topic,
+            stats.category,
+            stats.subcategory,
             stats.metric,
             stats.type,
             stats.value
         FROM stats
         WHERE stats.collected BETWEEN start_time AND end_time
-            AND stats.metric = metric;
+            AND stats.metric = vmetric;
 END;
 $$ LANGUAGE plpgsql;
 
-/* Create get_stat function limits what's returned to a start, ending timestamp, metric name and type */
+/* Create a get_stat overload */
 DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP, TEXT, TEXT);
 CREATE FUNCTION get_stat (
     start_time TIMESTAMP,
     end_time TIMESTAMP,
-    matric TEXT,
-    metric_type TEXT
+    vmatric TEXT,
+    vtype TEXT
 )
 RETURNS TABLE(
     collected TIMESTAMP,
+    topic TEXT,
+    category TEXT,
+    subcategory TEXT,
     metric TEXT,
     type TEXT,
     value TEXT
@@ -123,12 +150,126 @@ RETURNS TABLE(
 BEGIN
     RETURN QUERY
         SELECT stats.collected,
+            stats.topic,
+            stats.category,
+            stats.subcategory,
             stats.metric,
             stats.type,
             stats.value
         FROM stats
         WHERE stats.collected BETWEEN start_time AND end_time
-            AND stats.metric = metric
-            AND stats.type = metric_type;
+            AND stats.metric = vmetric
+            AND stats.type = vtype;
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create a get_stat overload */
+DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP, TEXT, TEXT, TEXT);
+CREATE FUNCTION get_stat (
+    start_time TIMESTAMP,
+    end_time TIMESTAMP,
+    vtopic TEXT,
+    vmatric TEXT,
+    vtype TEXT
+)
+RETURNS TABLE(
+    collected TIMESTAMP,
+    topic TEXT,
+    category TEXT,
+    subcategory TEXT,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+        SELECT stats.collected,
+            stats.topic,
+            stats.category,
+            stats.subcategory,
+            stats.metric,
+            stats.type,
+            stats.value
+        FROM stats
+        WHERE stats.collected BETWEEN start_time AND end_time
+            AND stats.metric = vmetric
+            AND stats.type = vtype
+            AND stats.topic = vtopic;
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create a get_stat overload */
+DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP, TEXT, TEXT, TEXT, TEXT);
+CREATE FUNCTION get_stat (
+    start_time TIMESTAMP,
+    end_time TIMESTAMP,
+    vtopic TEXT,
+    vcategory TEXT,
+    vmatric TEXT,
+    vtype TEXT
+)
+RETURNS TABLE(
+    collected TIMESTAMP,
+    topic TEXT,
+    category TEXT,
+    subcategory TEXT,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+        SELECT stats.collected,
+            stats.topic,
+            stats.category,
+            stats.subcategory,
+            stats.metric,
+            stats.type,
+            stats.value
+        FROM stats
+        WHERE stats.collected BETWEEN start_time AND end_time
+            AND stats.metric = vmetric
+            AND stats.type = vtype
+            AND stats.topic = vtopic
+            AND stats.category = vcategory;
+END;
+$$ LANGUAGE plpgsql;
+
+/* Create a get_stat overload */
+DROP FUNCTION IF EXISTS get_stat(TIMESTAMP, TIMESTAMP, TEXT, TEXT, TEXT, TEXT, TEXT);
+CREATE FUNCTION get_stat (
+    start_time TIMESTAMP,
+    end_time TIMESTAMP,
+    vtopic TEXT,
+    vcategory TEXT,
+    vsubcategory TEXT,
+    vmatric TEXT,
+    vtype TEXT
+)
+RETURNS TABLE(
+    collected TIMESTAMP,
+    topic TEXT,
+    category TEXT,
+    subcategory TEXT,
+    metric TEXT,
+    type TEXT,
+    value TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+        SELECT stats.collected,
+            stats.topic,
+            stats.category,
+            stats.subcategory,
+            stats.metric,
+            stats.type,
+            stats.value
+        FROM stats
+        WHERE stats.collected BETWEEN start_time AND end_time
+            AND stats.metric = vmetric
+            AND stats.type = vtype
+            AND stats.topic = vtopic
+            AND stats.category = vcategory
+            AND stats.subcategory = vsubcategory;
 END;
 $$ LANGUAGE plpgsql;

--- a/psql/init.sql
+++ b/psql/init.sql
@@ -1,5 +1,5 @@
 /*
-    Create a table to hold all bakula stats
+    Create a table to hold all statsd stats
 
     This table is going to be written to with high frequency but since it needs
     to provide stats in real time we have to both write and read with high frequency.

--- a/psql/init.sql
+++ b/psql/init.sql
@@ -3,9 +3,7 @@
 
     This table is going to be written to with high frequency but since it needs
     to provide stats in real time we have to both write and read with high frequency.
-    Therefore we are only indexing collected so further queries minimize their table
-    scans to a specific timeframe (all get calls request a start and end time). This
-    may need to be revised later on.
+    Therefore let's limit indexing to as much as possible.
 */
 CREATE TABLE IF NOT EXISTS stats (
     collected TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/statsdPostgresBackend.js
+++ b/statsdPostgresBackend.js
@@ -1,0 +1,165 @@
+/*
+    This is a backend for the etsy/statsd service designed to dump stats
+    into PostgreSQL
+*/
+
+module.exports = (function() {
+    "use strict";
+    var fs = require("fs");
+    var pg = require("pg");
+    var path = require("path");
+
+    // Items we don't want to store but are sent with every statsd flush
+    var IGNORED_STATSD_METRICS = [
+        "statsd.bad_lines_seen",
+        "statsd.packets_received",
+        "statsd.metrics_received",
+        "statsd.timestamp_lag",
+        "processing_time"
+    ];
+
+    // The various statsd types as per https://github.com/etsy/statsd/blob/master/docs/metric_types.md
+    var STATSD_TYPES = {
+        counting: "c",
+        timing: "ms",
+        gauges: "g",
+        sets: "s"
+    };
+
+    // The path to the SQL script that initializes the table and functions
+    var INITIALIZE_SQL_SCRIPT_FILE_PATH = path.join(__dirname, "psql", "init.sql");
+
+    // PostgreSQL configuration properties for module-wide access
+    var pghost;
+    var pgdb;
+    var pgport;
+    var pguser;
+    var pgpass;
+
+    // Generated and cached PostgreSQL connection string
+    var connStr;
+
+    // Return connection string; this lets it be lazy loaded
+    var connectionString = function() {
+        if (connStr === undefined) {
+            connStr = "postgres://";
+            connStr += (pguser) ? pguser : "";
+            connStr += (pguser && pgpass) ? ":" + pgpass : "";
+            connStr += (pguser) ? "@" : "";
+            connStr += (pghost) ? pghost + ":" + pgport : "";
+            connStr += (pgdb) ? "/" + pgdb : "";
+        }
+        return connStr;
+    }
+
+    // Calling this method grabs a connection to PostgreSQL from the connection pool
+    // then returns a client to be used.
+    var conn = function(callback) {
+        pg.connect(connectionString(), function(err, client, done) {
+            return callback(err, client, done);
+        });
+    };
+
+    // Create stats table and functions should they not exist
+    var initializePSQL = function(callback) {
+        conn(function(err, client, done) {
+            if (err) {
+                return callback(err);
+            }
+            client.query(fs.readFileSync(INITIALIZE_SQL_SCRIPT_FILE_PATH, { encoding: "utf8" }), function(queryErr, queryResult) {
+                if (queryErr) {
+                    done();
+                    return callback(queryErr);
+                }
+                done();
+                return callback(null, queryResult);
+            });
+        });
+    };
+
+    // Insert new metrics values
+    var insertMetric = function(timestamp, metric, mtype, value, callback) {
+        conn(function(err, client, done) {
+            if (err) {
+                return callback(err);
+            }
+
+            client.query({
+                text: "SELECT add_stat($1, $2, $3)",
+                values: [metric, mtype, value]
+            }, function(queryErr, queryResult) {
+                done();
+                if (queryErr) {
+                    return callback(queryErr);
+                }
+                return callback(null, queryResult);
+            });
+        });
+    };
+
+    // Inserts multiple metrics records
+    var insertMetrics = function(metrics, callback) {
+        var context = this;
+        var metrics_copy = (metrics || []).slice(0);
+        if (metrics_copy.length === 0) {
+            return callback([], []);
+        }
+        var errResult = [];
+        var goodResult = [];
+        var metric = metrics_copy.shift();
+
+        var processMetric = function(metric) {
+            insertMetric.apply(context, metric.concat(function(err, result) {
+                if (err) {
+                    errResult.push(err);
+                } else {
+                    goodResult.push(result);
+                }
+
+                var metric = metrics_copy.shift();
+                if (metric === undefined) {
+                    return callback(errResult, goodResult);
+                }
+                return processMetric(metric);
+            }));
+        };
+        processMetric(metric);
+    };
+
+    return {
+        init: function(startup_time, config, events, logger) {
+            pgdb = config.pgdb;
+            pghost = config.pghost;
+            pgport = config.pgport || 5432;
+            pguser = config.pguser;
+            pgpass = config.pgpass;
+
+            initializePSQL(function(err) {
+                if (err) {
+                    return console.error(err);
+                }
+            });
+
+            events.on("flush", function(timestamp, statsdMetrics) {
+                var metrics = [];
+                for (var key in statsdMetrics.counters) {
+                    if (statsdMetrics.counters.hasOwnProperty(key) && IGNORED_STATSD_METRICS.indexOf(key) === -1) {
+                        metrics.push([timestamp, STATSD_TYPES.counting, key, statsdMetrics.counters[key]]);
+                    }
+                }
+
+                insertMetrics(metrics, function(errs, goods) {
+                    if (errs.length > 0) {
+                        console.error(errs);
+                    }
+                });
+            });
+
+            events.on("status", function(callback) {
+                callback(null, "postgresBackend", null, null);
+            });
+
+            return true;
+        }
+    };
+}());

--- a/statsdPostgresBackend.js
+++ b/statsdPostgresBackend.js
@@ -40,9 +40,6 @@ module.exports = (function() {
     // Generated and cached PostgreSQL connection string
     var connStr;
 
-    // Matchy match on curley brackets
-    var curleyRegex = new RegExp(/{(.*?)}/);
-
     // Return connection string; this lets it be lazy loaded
     // Handles cases where user and password or just password is omitted
     var connectionString = function() {

--- a/statsdPostgresBackend.js
+++ b/statsdPostgresBackend.js
@@ -172,6 +172,10 @@ module.exports = (function() {
             pguser = config.pguser;
             pgpass = config.pgpass;
 
+            if (config.pginit !== true) {
+                INITIALIZE_SQL_SCRIPT_FILE_PATH = undefined;
+            }
+
             initializePSQL(function(err) {
                 if (err) {
                     return console.error(err);


### PR DESCRIPTION
I was originally looking at [this backend](https://github.com/snookie/nodejs-statsd-psql-backend) but it didn't work nor did it function like the other backends (it tries to do updates etc, all other backends simply record data and leave it up to the user to fetch the correct information). So using the [mysql statsd backend](https://github.com/fradinni/nodejs-statsd-mysql-backend) as a little bit of a template I created this one for PostgreSQL.

There are differences with this than regular statsd backends however.

1. This supports complex keys and buckets them into topics, categories and subcategories (I tried to make these as generic as possible since this is technically not part of bakula) but also supports standard key values typically sent via statsd. It uses a ```__``` as a delimiter (which is weird but statsd strips out all other characters; not much choice here and I didn't want to try modifying statsd itself).

2. This includes PostgreSQL functions ```add_stat()``` and ```get_stat()``` to support adding and getting stats whereas most statsd backends only deal with adding them.

To test this clone ```https://github.com/etsy/statsd```, edit a configuration to include the following:
```javascript
{
  pghost: "0.0.0.0",
  pguser: "user",
  pgpass: undefined,
  pgdb: "postgres",
  pgport: 5432,
  pginit: true,
  port: 8125,
  backends: [ "<path to>/Statsd-PostgreSQL-Backend/statsdPostgresBackend" ]
}
```

The PostgreSQL user must have the ability to create tables and functions. Alternatively manually run the included SQL script at ```psql/init.sql``` then set the ```pginit``` config option to false.

@immuta/developers 