### PR TITLE
Fixed issue where a violation of the primary key constraint could occur

### DIFF
--- a/psql/init.sql
+++ b/psql/init.sql
@@ -33,12 +33,8 @@ BEGIN
     WHERE NOT EXISTS (SELECT 1
         FROM stats
         WHERE stats.collected = vcollected
-        AND stats.topic = vtopic
-        AND stats.category = vcategory
-        AND stats.subcategory = vsubcategory
         AND stats.metric = vmetric
         AND stats.type = vtype
-        AND stats.value = vvalue
     );
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
The primary constraint on the stats table is based only on the required fields for statsd, not our extended fields (otherwise it wouldn't quire work like other statsd backends) but the adding of stats was taking this *plus* the extended fields into account which was a mistake. It worked previously but certain stats additions would throw a primary key constraint error.

@immuta/developers 

![image](https://cloud.githubusercontent.com/assets/1885826/13167215/f61759f0-d69e-11e5-8ed3-df02b391e505.png)
